### PR TITLE
Generate thumbnails when transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
   apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y --no-install-recommends \
+    bc \
     build-essential \
     curl \
     cython \


### PR DESCRIPTION
Re-uses calculations from oam-uploader-api to determine target image size.

Fixes #11 
