### PR TITLE
Imagery sans masks

### DIFF
--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -18,7 +18,7 @@ def get_metadata(prefix):
     scene = "{}.tif".format(prefix)
     scene_vrt = "{}_warped.vrt".format(prefix)
     mask_vrt = "{}_warped_mask.vrt".format(prefix)
-    fooprint = "{}_footprint.json".format(prefix)
+    footprint = "{}_footprint.json".format(prefix)
 
     with rasterio.Env():
         # TODO this assumes US Standard region
@@ -57,6 +57,6 @@ if __name__ == "__main__":
     input = sys.argv[1]
     try:
         print(json.dumps(get_metadata(input)))
-    except (IOError, rasterio._err.CPLE_HttpResponse):
+    except (IOError, rasterio._err.CPLE_HttpResponseError):
         print("Unable to open '{}'.".format(input), file=sys.stderr)
         exit(1)

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -8,55 +8,60 @@ import math
 import os
 import sys
 
+import click
 import rasterio
 from rasterio.warp import transform_bounds
 
 from get_zoom import get_zoom, get_zoom_offset
 
 
-def get_metadata(prefix):
+@click.command()
+@click.option("--include-mask", is_flag=True, help="Include a mask URL")
+@click.argument("prefix")
+def get_metadata(include_mask, prefix):
     scene = "{}.tif".format(prefix)
     scene_vrt = "{}_warped.vrt".format(prefix)
     mask_vrt = "{}_warped_mask.vrt".format(prefix)
     footprint = "{}_footprint.json".format(prefix)
 
     with rasterio.Env():
-        # TODO this assumes US Standard region
-        with rasterio.open(scene.replace("s3://", "/vsicurl/http://s3.amazonaws.com/")) as src:
-            bounds = transform_bounds(src.crs, {'init': 'epsg:4326'}, *src.bounds)
-            approximate_zoom = get_zoom(scene)
-            maxzoom = max(approximate_zoom + 3, 22)
-            minzoom = max(approximate_zoom - get_zoom_offset(src.width, src.height, approximate_zoom), 0)
-            source = scene_vrt.replace("s3://", "http://s3.amazonaws.com/")
-            mask = mask_vrt.replace("s3://", "http://s3.amazonaws.com/")
-            footprint = footprint.replace("s3://", "http://s3.amazonaws.com/")
+        input = scene.replace("s3://", "/vsicurl/http://s3.amazonaws.com/")
+        try:
+            # TODO this assumes US Standard region
+            with rasterio.open(input) as src:
+                bounds = transform_bounds(src.crs, {'init': 'epsg:4326'}, *src.bounds)
+                approximate_zoom = get_zoom(scene)
+                maxzoom = max(approximate_zoom + 3, 22)
+                minzoom = max(approximate_zoom - get_zoom_offset(src.width, src.height, approximate_zoom), 0)
+                source = scene_vrt.replace("s3://", "http://s3.amazonaws.com/")
+                mask = mask_vrt.replace("s3://", "http://s3.amazonaws.com/")
+                footprint = footprint.replace("s3://", "http://s3.amazonaws.com/")
 
-            return {
-              "bounds": bounds,
-              "center": [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2, (minzoom + approximate_zoom) / 2],
-              "maxzoom": maxzoom,
-              "meta": {
-                "approximateZoom": approximate_zoom,
-                "footprint": footprint,
-                "height": src.height,
-                "mask": mask,
-                "source": source,
-                "width": src.width,
-              },
-              "minzoom": minzoom,
-              # TODO provide a name
-              "name": prefix,
-              "tilejson": "2.1.0"
-            }
+                meta = {
+                  "bounds": bounds,
+                  "center": [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2, (minzoom + approximate_zoom) / 2],
+                  "maxzoom": maxzoom,
+                  "meta": {
+                    "approximateZoom": approximate_zoom,
+                    "footprint": footprint,
+                    "height": src.height,
+                    "source": source,
+                    "width": src.width,
+                  },
+                  "minzoom": minzoom,
+                  # TODO provide a name
+                  "name": prefix,
+                  "tilejson": "2.1.0"
+                }
+
+                if include_mask:
+                    meta['meta']['mask'] = mask
+
+                print(json.dumps(meta))
+        except (IOError, rasterio._err.CPLE_HttpResponseError) as e:
+            print("Unable to open '{}': {}".format(input, e), file=sys.stderr)
+            exit(1)
+
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
-        print("usage: {} <scene>".format(os.path.basename(sys.argv[0])), file=sys.stderr)
-        exit(1)
-
-    input = sys.argv[1]
-    try:
-        print(json.dumps(get_metadata(input)))
-    except (IOError, rasterio._err.CPLE_HttpResponseError):
-        print("Unable to open '{}'.".format(input), file=sys.stderr)
-        exit(1)
+    get_metadata()

--- a/bin/make_vrt.sh
+++ b/bin/make_vrt.sh
@@ -3,9 +3,13 @@
 set -eo pipefail
 
 resampling_method="near"
+dstalpha=""
 
-while getopts ":r:" opt; do
+while getopts ":r:a" opt; do
   case $opt in
+    a)
+      dstalpha="-dstalpha"
+      ;;
     r)
       resampling_method=$OPTARG
       ;;
@@ -37,6 +41,7 @@ gdalwarp \
   /vsicurl/${http_source} \
   $output \
   -r $resampling_method \
+  $dstalpha \
   -t_srs epsg:3857 \
   -of VRT \
   -te -20037508.34 -20037508.34 20037508.34 20037508.34 \

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -38,34 +38,61 @@ rm -f $source
 # 3. upload TIF
 >&2 echo "Uploading..."
 aws s3 cp $intermediate ${output}.tif --acl public-read
-rm -f $intermediate
 
-# 4. upload mask
->&2 echo "Uploading mask..."
-aws s3 cp ${intermediate}.msk ${output}.tif.msk --acl public-read
-rm -f ${intermediate}.msk*
+if [ -f ${intermediate}.msk ]; then
+  mask=1
 
-# 5. create RGBA VRT (for use in QGIS, etc.)
->&2 echo "Generating RGBA VRT..."
-vrt=$(mktemp)
-http_output=${output/s3:\/\//http:\/\/s3.amazonaws.com\/}
-gdal_translate \
-  -b 1 \
-  -b 2 \
-  -b 3 \
-  -b mask \
-  -of VRT \
-  /vsicurl/${http_output}.tif $vrt
+  # 4. upload mask
+  >&2 echo "Uploading mask..."
+  aws s3 cp ${intermediate}.msk ${output}.tif.msk --acl public-read
 
-perl -pe 's!(band="4"\>)!\1\n    <ColorInterp>Alpha</ColorInterp>!' $vrt | \
-  perl -pe "s|/vsicurl/${http_output}|$(basename $output)|" | \
-  perl -pe 's|(relativeToVRT=)"0"|$1"1"|' | \
-  aws s3 cp - ${output}.vrt --acl public-read
+  # 5. create RGBA VRT (for use in QGIS, etc.)
+  >&2 echo "Generating RGBA VRT..."
+  vrt=$(mktemp)
+  http_output=${output/s3:\/\//http:\/\/s3.amazonaws.com\/}
+  gdal_translate \
+    -b 1 \
+    -b 2 \
+    -b 3 \
+    -b mask \
+    -of VRT \
+    /vsicurl/${http_output}.tif $vrt
 
-# 6. create footprint
->&2 echo "Generating footprint..."
-rio shapes --mask --sampling 10 --precision 6 $vrt | \
-  aws s3 cp - ${output}_footprint.json --acl public-read
+  perl -pe 's!(band="4"\>)!\1\n    <ColorInterp>Alpha</ColorInterp>!' $vrt | \
+    perl -pe "s|/vsicurl/${http_output}|$(basename $output)|" | \
+    perl -pe 's|(relativeToVRT=)"0"|$1"1"|' | \
+    aws s3 cp - ${output}.vrt --acl public-read
+
+  # 6. create footprint
+  >&2 echo "Generating footprint..."
+  rio shapes --mask --as-mask --sampling 100 --precision 6 $intermediate | \
+    aws s3 cp - ${output}_footprint.json --acl public-read
+else
+  mask=0
+
+  # 5. create RGB VRT (for parity)
+  >&2 echo "Generating RGB VRT..."
+  vrt=$(mktemp)
+  http_output=${output/s3:\/\//http:\/\/s3.amazonaws.com\/}
+  gdal_translate \
+    -b 1 \
+    -b 2 \
+    -b 3 \
+    -of VRT \
+    /vsicurl/${http_output}.tif $vrt
+
+  cat $vrt | \
+    perl -pe "s|/vsicurl/${http_output}|$(basename $output)|" | \
+    perl -pe 's|(relativeToVRT=)"0"|$1"1"|' | \
+    aws s3 cp - ${output}.vrt --acl public-read
+
+  # 6. create footprint (bounds of image)
+  >&2 echo "Generating footprint..."
+  rio bounds $intermediate | \
+    aws s3 cp - ${output}_footprint.json --acl public-read
+fi
+
+rm -f $intermediate ${intermediate}.msk*
 
 # 7. create thumbnail
 >&2 echo "Generating thumbnail..."
@@ -80,17 +107,30 @@ gdal_translate -of png $vrt $thumb -outsize $target_width $target_height
 aws s3 cp $thumb ${output}_thumb.png --acl public-read
 rm -f $vrt $thumb
 
-# 8. create and upload warped VRT
->&2 echo "Generating warped VRT..."
-warped_vrt=$(mktemp)
-make_vrt.sh -r lanczos ${output}.tif > $warped_vrt
-aws s3 cp $warped_vrt ${output}_warped.vrt --acl public-read
+if [ "$mask" -eq 1 ]; then
+  # 8. create and upload warped VRT
+  >&2 echo "Generating warped VRT..."
+  warped_vrt=$(mktemp)
+  make_vrt.sh -r lanczos ${output}.tif > $warped_vrt
+  aws s3 cp $warped_vrt ${output}_warped.vrt --acl public-read
 
-# 9. create and upload warped VRT for mask
->&2 echo "Generating warped VRT for mask..."
-make_mask_vrt.py $warped_vrt | aws s3 cp - ${output}_warped_mask.vrt --acl public-read
+  # 9. create and upload warped VRT for mask
+  >&2 echo "Generating warped VRT for mask..."
+  make_mask_vrt.py $warped_vrt | aws s3 cp - ${output}_warped_mask.vrt --acl public-read
+else
+  # 8. create and upload warped VRT
+  >&2 echo "Generating warped VRT..."
+  warped_vrt=$(mktemp)
+  make_vrt.sh -r lanczos -a ${output}.tif > $warped_vrt
+  aws s3 cp $warped_vrt ${output}_warped.vrt --acl public-read
+fi
+
 rm -f $warped_vrt
 
 # 10. create and upload metadata
 >&2 echo "Generating metadata..."
-get_metadata.py $output | aws s3 cp - ${output}.json --acl public-read
+if [ "$mask" -eq 1 ]; then
+  get_metadata.py --include-mask $output | aws s3 cp - ${output}.json --acl public-read
+else
+  get_metadata.py $output | aws s3 cp - ${output}.json --acl public-read
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cachetools
+click
 flask
 flask-cors
 mercantile


### PR DESCRIPTION
When creating warped VRTs, `-dstalpha` is now used to provide an implicit alpha mask based on the bounds of the image (when none is otherwise available). `app.py` now understands how to deal with 3- and 4-band sources w/o masks.

`bin/get_metadata.py` picked up a `--include-mask` argument (facilitated by [click](http://click.pocoo.org/5/)) that can be omitted when masks are not generated.

Fixes #6 