### PR TITLE
Added Rpmdb checksum workaround for yum

### DIFF
--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -3,7 +3,8 @@ FROM lambci/lambda:build-python2.7
 # Install deps
 
 RUN \
-  yum install -y \
+  touch /var/lib/rpm/* \
+  && yum install -y \
     automake16 \
     libcurl-devel \
     libpng-devel


### PR DESCRIPTION
I was seeing [this documented error](https://docs.oracle.com/cd/E52668_01/E69348/html/uek4-czc_xmc_xt.html):

> Rpmdb checksum is invalid: dCDPT(pkg checksums): libcurl-devel.x86_64 0:7.40.0-8.59.amzn1 - u

It also occurred with automake, but not libpng-devel. This change applies [the workaround from the Oracle suggestion](https://docs.oracle.com/cd/E52668_01/E69348/html/uek4-czc_xmc_xt.html).