### PR TITLE
Default TMPDIR:-/tmp. Increase timeout to 2 hours

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# See https://github.com/mojodna/docker-gdal22
 FROM quay.io/mojodna/gdal22
 MAINTAINER Seth Fitzsimmons <seth@mojodna.net>
 

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -6,9 +6,14 @@ shift $[$#-2]
 
 input=$1
 output=$2
-# target size in KB
-THUMBNAIL_SIZE=${THUMBNAIL_SIZE:-300}
+
+THUMBNAIL_SIZE=${THUMBNAIL_SIZE:-300} # target size in KB
 TILER_BASE_URL=${TILER_BASE_URL:-http://tiles.openaerialmap.org}
+
+# Although TMPDIR is usually set by the OS, it doesn't seem to be getting passed through
+# Docker and Node's `spawn()`, so no harm done in just defaulting to `/tmp` in such cases.
+# There may be clues here as the underlying issue: https://github.com/npm/npm/issues/4531
+TMPDIR={TMPDIR:-/tmp}
 
 set -euo pipefail
 

--- a/bin/transcode.sh
+++ b/bin/transcode.sh
@@ -56,7 +56,7 @@ for b in $(seq 1 $count); do
 done
 
 >&2 echo "Transcoding bands..."
-timeout --foreground 1h gdal_translate \
+timeout --foreground 2h gdal_translate \
   $bands \
   $mask \
   -co TILED=yes \
@@ -76,7 +76,7 @@ for z in $(seq 1 $zoom); do
 done
 
 >&2 echo "Adding overviews..."
-timeout --foreground 1h gdaladdo \
+timeout --foreground 2h gdaladdo \
   -r lanczos \
   --config GDAL_TIFF_OVR_BLOCKSIZE 512 \
   --config TILED_OVERVIEW yes \
@@ -89,7 +89,7 @@ timeout --foreground 1h gdaladdo \
 
 if [ "$mask" != "" ]; then
   >&2 echo "Adding overviews to mask..."
-  timeout --foreground 1h gdaladdo \
+  timeout --foreground 2h gdaladdo \
     --config GDAL_TIFF_OVR_BLOCKSIZE 512 \
     --config TILED_OVERVIEW yes \
     --config COMPRESS_OVERVIEW DEFLATE \


### PR DESCRIPTION
This concerns the lessons learned from dealing with the recent large gtiff problem here: https://github.com/hotosm/oam-uploader/issues/78#issuecomment-311326334